### PR TITLE
Fix code scanning alert no. 2: Log entries created from user input

### DIFF
--- a/Web/Services/EmailService.cs
+++ b/Web/Services/EmailService.cs
@@ -20,7 +20,8 @@ public class EmailService
 
     public async Task<MessageSentEventArgs> SendEmailAsync(string subject, string body, string toName, string toAddress)
     {
-        _logger.LogDebug("Sending email, subject: {Subject}, recipient: {ToAddress}", subject, toAddress);
+        var sanitizedToAddress = toAddress.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        _logger.LogDebug("Sending email, subject: {Subject}, recipient: {ToAddress}", subject, sanitizedToAddress);
         body += $"<br><p>This message was automatically sent by {BlogLink}, no need to reply.</p>";
         return await EmailUtils.SendEmailAsync(_emailAccountConfig, subject, body, toName, toAddress);
     }


### PR DESCRIPTION
Fixes [https://github.com/shimakaze09/Blog/security/code-scanning/2](https://github.com/shimakaze09/Blog/security/code-scanning/2)

To fix the problem, we need to sanitize the `toAddress` parameter before logging it. Since the log entries are plain text, we should remove any newline characters from the `toAddress` to prevent log forging attacks. This can be done using the `String.Replace` method to replace newline characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved email logging by sanitizing recipient addresses to remove newline characters, enhancing the reliability of email delivery.
  
- **Chores**
	- No changes made to the existing email sending logic or methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->