### PR TITLE
Fix code scanning alert no. 1: Unsafe HTML constructed from library input

### DIFF
--- a/Web/wwwroot/js/bootstrap-treeview.js
+++ b/Web/wwwroot/js/bootstrap-treeview.js
@@ -651,29 +651,39 @@
         }
     };
 
+    // Helper function to escape unsafe characters
+    Tree.prototype.escapeHtml = function (unsafe) {
+        return unsafe
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;");
+    };
+
     // Construct trees style based on user options
     Tree.prototype.buildStyle = function () {
 
         let style = '.node-' + this.elementId + '{';
 
         if (this.options.color) {
-            style += 'color:' + this.options.color + ';';
+            style += 'color:' + this.escapeHtml(this.options.color) + ';';
         }
 
         if (this.options.backColor) {
-            style += 'background-color:' + this.options.backColor + ';';
+            style += 'background-color:' + this.escapeHtml(this.options.backColor) + ';';
         }
 
         if (!this.options.showBorder) {
             style += 'border:none;';
         } else if (this.options.borderColor) {
-            style += 'border:1px solid ' + this.options.borderColor + ';';
+            style += 'border:1px solid ' + this.escapeHtml(this.options.borderColor) + ';';
         }
         style += '}';
 
         if (this.options.onhoverColor) {
             style += '.node-' + this.elementId + ':not(.node-disabled):hover{' +
-                'background-color:' + this.options.onhoverColor + ';' +
+                'background-color:' + this.escapeHtml(this.options.onhoverColor) + ';' +
                 '}';
         }
 


### PR DESCRIPTION
Fixes [https://github.com/shimakaze09/Blog/security/code-scanning/1](https://github.com/shimakaze09/Blog/security/code-scanning/1)

To fix the problem, we need to ensure that any user-supplied data in the `options` object is sanitized before being used to construct HTML. This can be achieved by escaping any potentially unsafe characters in the `options` properties before constructing the style string.

The best way to fix this without changing existing functionality is to create a helper function that escapes unsafe characters and use this function in the `buildStyle` method. This will ensure that any data used in constructing the style string is safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to sanitize user-defined styles in the tree view, enhancing security by preventing unsafe HTML injection.

- **Documentation**
	- Updated comments to reflect the new functionality of the HTML escaping method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->