### PR TITLE
Potential fix for code scanning alert no. 9: Exposure of private information

### DIFF
--- a/Web/Services/EmailService.cs
+++ b/Web/Services/EmailService.cs
@@ -11,6 +11,21 @@ public class EmailService
     private readonly EmailAccountConfig _emailAccountConfig;
     private readonly ILogger<EmailService> _logger;
 
+    private static string MaskEmail(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email)) return string.Empty;
+
+        var atIndex = email.IndexOf('@');
+        if (atIndex <= 0 || atIndex == email.Length - 1) return "***";
+
+        var localPart = email.Substring(0, atIndex);
+        var domainPart = email.Substring(atIndex + 1);
+
+        if (localPart.Length <= 1)
+            return "*@" + domainPart;
+
+        return localPart[0] + new string('*', Math.Max(1, localPart.Length - 1)) + "@" + domainPart;
+    }
 
     public EmailService(ILogger<EmailService> logger, IOptions<EmailAccountConfig> options)
     {
@@ -21,7 +36,8 @@ public class EmailService
     public async Task<MessageSentEventArgs> SendEmailAsync(string subject, string body, string toName, string toAddress)
     {
         var sanitizedToAddress = toAddress.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
-        _logger.LogDebug("Sending email, subject: {Subject}, recipient: {ToAddress}", subject, sanitizedToAddress);
+        var maskedToAddress = MaskEmail(sanitizedToAddress);
+        _logger.LogDebug("Sending email, subject: {Subject}, recipient: {ToAddress}", subject, maskedToAddress);
         body += $"<br><p>This message was automatically sent by {BlogLink}, no need to reply.</p>";
         return await EmailUtils.SendEmailAsync(_emailAccountConfig, subject, body, toName, toAddress);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/shimakaze09/Blog/security/code-scanning/9](https://github.com/shimakaze09/Blog/security/code-scanning/9)

In general, the fix is to ensure that private data (the user’s email address) is not written verbatim to logs or other external locations. For this case, that means changing the debug log line in `EmailService.SendEmailAsync` so it does not include the full `toAddress`, but instead either omits the email entirely or logs only a redacted/masked form (for example, partial local part and domain). We should preserve existing functionality—emails must still be sent to the real address, and logs remain useful for diagnostics.

The best minimal fix is to introduce a small helper in `EmailService` that masks an email address (e.g., keeps the first character of the local part and the domain, replacing the rest with asterisks), and use that masked value in the debug log instead of the raw address. This keeps the log informative (“which email roughly was used”) without exposing the full address. Concretely, in `Web/Services/EmailService.cs`, we will: (1) add a private static method `MaskEmail(string email)` above `SendEmailAsync`; (2) in `SendEmailAsync`, keep the newline sanitization for safety but then derive a `maskedToAddress = MaskEmail(sanitizedToAddress);`; and (3) change the `LogDebug` call to log `maskedToAddress` instead of `sanitizedToAddress`. No changes are required to `CommentController` or `CommentService` because the only problematic sink is the logging line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Email addresses are now masked in debug logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->