### PR TITLE
Potential fix for code scanning alert no. 10: Exposure of private information

### DIFF
--- a/Web/Services/EmailService.cs
+++ b/Web/Services/EmailService.cs
@@ -35,9 +35,7 @@ public class EmailService
 
     public async Task<MessageSentEventArgs> SendEmailAsync(string subject, string body, string toName, string toAddress)
     {
-        var sanitizedToAddress = toAddress.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
-        var maskedToAddress = MaskEmail(sanitizedToAddress);
-        _logger.LogDebug("Sending email, subject: {Subject}, recipient: {ToAddress}", subject, maskedToAddress);
+        _logger.LogDebug("Sending email with subject: {Subject}", subject);
         body += $"<br><p>This message was automatically sent by {BlogLink}, no need to reply.</p>";
         return await EmailUtils.SendEmailAsync(_emailAccountConfig, subject, body, toName, toAddress);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/shimakaze09/Blog/security/code-scanning/10](https://github.com/shimakaze09/Blog/security/code-scanning/10)

General approach: avoid writing private user email information to logs (an external location), or anonymize it so that the logged value cannot be used to identify a specific user. Since this logging is purely diagnostic, we can safely replace the email-based log parameter with a non-sensitive surrogate (for example, a hash) or remove it entirely.

Best targeted fix: in `Web/Services/EmailService.cs`, inside `SendEmailAsync`, change the debug logging so that it no longer includes `maskedToAddress` (derived from the user’s email). Instead, log only non-PII such as the subject and perhaps a stable, non-reversible identifier if needed. This addresses all variants because the taint path ends at this log call.

Concretely:
- In `EmailService.SendEmailAsync`, remove `sanitizedToAddress`, `maskedToAddress`, and their usage in `_logger.LogDebug`.
- Replace the log message with one that omits the email, for example:
  `_logger.LogDebug("Sending email with subject: {Subject}", subject);`
- No new imports or additional methods are required.

This single change keeps email sending behavior identical (the real `toAddress` is still passed to `EmailUtils.SendEmailAsync`) while eliminating logging of email-derived data, satisfying the recommendation to avoid storing private information in external locations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved debug logging practices to no longer expose recipient email information in logs, enhancing security and privacy safeguards while maintaining full email sending functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->